### PR TITLE
Close LDAP connections properly.

### DIFF
--- a/ldapdb/backends/ldap/base.py
+++ b/ldapdb/backends/ldap/base.py
@@ -86,7 +86,10 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         self.settings_dict['SUPPORTS_TRANSACTIONS'] = False
 
     def close(self):
-        pass
+        self.validate_thread_sharing()
+        if self.connection is not None:
+            self.connection.unbind_s()
+            self.connection = None
 
     def _commit(self):
         pass


### PR DESCRIPTION
Implement the `close()` method in DatabaseWrapper so that the connection to LDAP is actually unbound and closed properly as necessary. This seems to fix issues with mockldap which tampakrap is working on supporting. It will be also necessary for the rebinding support I'm working on.
