### PR TITLE
fix for AD servers (we have not to follow anyway via connection options)

### DIFF
--- a/ldapdb/backends/ldap/base.py
+++ b/ldapdb/backends/ldap/base.py
@@ -74,7 +74,7 @@ class DatabaseOperations(BaseDatabaseOperations):
 
 class DatabaseWrapper(BaseDatabaseWrapper):
     vendor = 'ldap'
-    
+
     def __init__(self, *args, **kwargs):
         super(DatabaseWrapper, self).__init__(*args, **kwargs)
 
@@ -145,5 +145,6 @@ class DatabaseWrapper(BaseDatabaseWrapper):
                                              attrlist)
         output = []
         for dn, attrs in results:
-            output.append((dn.decode(self.charset), attrs))
+            if dn is not None:
+                output.append((dn.decode(self.charset), attrs))
         return output


### PR DESCRIPTION
Hello, with this trivial patch ldapdb can work with AD servers that respond with referrals such as:

> > ldapConn.search_s(...)
> > [(None, ['ldap://ForestDnsZones.xx/DC=ForestDnsZones,DC=xx']),
> >  (None, ['ldap://DomainDnsZones.xx/DC=DomainDnsZones,DC=xx']),
> >  (None, ['ldap://xx/CN=Configuration,DC=xx'])]

Hope this helps, ciao
