### PR TITLE
using ldapdb Model.scoped() classmethod to always have scoped instances

### DIFF
--- a/ldapdb/models/base.py
+++ b/ldapdb/models/base.py
@@ -148,13 +148,10 @@ class Model(django.db.models.base.Model):
                 if new_dn != self.dn:
                     logger.debug("Renaming LDAP entry %s to %s" % (self.dn,
                                                                    new_dn))
-                    print "Renaming LDAP entry %s to %s" % (self.dn,
-                                                                   new_dn)
                     connection.rename_s(self.dn, self.build_rdn())
                     self.dn = new_dn
 
                 logger.debug("Modifying existing LDAP entry %s" % self.dn)
-                print "Modifying existing LDAP entry %s" % self.dn, modlist
                 connection.modify_s(self.dn, modlist)
             else:
                 logger.debug("No changes to be saved to LDAP entry %s" %


### PR DESCRIPTION
Ciao, please consider merging this little modification, it let to always have a scoped instance and this fixes problems like issue #3. I think that's very inobtrusive, but just "fix" the build_*dn stuff so it behaves correctly

thank you, ciao !
