### PR TITLE
Allow to override base_dn for model in settings

### DIFF
--- a/examples/models.py
+++ b/examples/models.py
@@ -89,3 +89,16 @@ class LdapGroup(ldapdb.models.Model):
 
     def __unicode__(self):
         return self.name
+
+
+class LdapPerson(ldapdb.models.Model):
+    """
+    Class for representing LDAP person entry (a few required field number)
+    """
+    object_classes = ['person']
+
+    name = CharField(db_column='cn', primary_key=True)
+    surname = CharField(db_column='sn', primary_key=True)
+
+    def __unicode__(self):
+        return self.name

--- a/ldapdb/models/base.py
+++ b/ldapdb/models/base.py
@@ -56,7 +56,7 @@ class ModelBase(django.db.models.base.ModelBase):
             try:
                 model.base_dn = db['OPTIONS']['base_dn']
             except KeyError:
-                if not model.base_dn:
+                if not model.base_dn and not model._meta.abstract:
                     # try to get highest available DN here?
                     raise Exception("Could not build Distinguished Name")
 

--- a/settings.py
+++ b/settings.py
@@ -27,6 +27,10 @@ DATABASES = {
 }
 DATABASE_ROUTERS = ['ldapdb.router.Router']
 
+LDAPDB_BASES = {
+    'examples': {'LdapPerson': 'ou=dynamic,dc=nodomain'}
+}
+
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 # although not all choices may be available on all operating systems.


### PR DESCRIPTION
In order to not be tied to base_dn set in application I added the option to override it globally in database `OPTIONS` or per model via `LDAPDB_BASES` dictionary.
