### PR TITLE
New kwargs for django.db.connection.creation methods in django>=1.7

### DIFF
--- a/ldapdb/backends/ldap/base.py
+++ b/ldapdb/backends/ldap/base.py
@@ -39,14 +39,15 @@ from django.db.backends.creation import BaseDatabaseCreation
 
 
 class DatabaseCreation(BaseDatabaseCreation):
-    def create_test_db(self, verbosity=1, autoclobber=False):
+    def create_test_db(self, verbosity=1, autoclobber=False,
+                       serialize=True, keepdb=False):
         """
         Creates a test database, prompting the user for confirmation if the
         database already exists. Returns the name of the test database created.
         """
         pass
 
-    def destroy_test_db(self, old_database_name, verbosity=1):
+    def destroy_test_db(self, old_database_name, verbosity=1, keepdb=False):
         """
         Destroy a test database, prompting the user for confirmation if the
         database already exists. Returns the name of the test database created.


### PR DESCRIPTION
[Described here](https://docs.djangoproject.com/en/dev/topics/testing/advanced/#django-db-connection-creation)
Maybe it should be `def create_test_db(self, **kwargs)`?
