### PR TITLE
allow object classes array modification

### DIFF
--- a/examples/tests.py
+++ b/examples/tests.py
@@ -490,6 +490,16 @@ class UserTestCase(TestCase):
         u.save()
         self.assertEquals(u.dn, 'uid=foouser2,%s' % LdapUser.base_dn)
 
+    def test_update_objectclass(self):
+        u = LdapUser.objects.get(username='foouser')
+        u.object_classes.append('person')
+        u.save()
+
+        # make sure DN gets updated if we change the pk
+        u.object_classes.remove('person')
+        u.save()
+        self.assertEquals(u.object_classes, ['posixAccount', 'shadowAccount', 'inetOrgPerson'])
+
 
 class ScopedTestCase(TestCase):
     directory = dict([admin, groups, people, foogroup, contacts])


### PR DESCRIPTION
Tentatively closes #55 

added a little magic in models.base for unobtrusively observing changes to Model.object_classes. If this array changes because any MutableSequence methods (https://docs.python.org/2/library/collections.html#collections-abstract-base-classes) then make an original copy to use when compiling sql filterstring, otherwise a search against still-to-be-changed objectclasses list raise a DoesNotExist

Thank you, ciao
