### PR TITLE
Fix #63: Encode default attribute of a ListField

### DIFF
--- a/examples/admin.py
+++ b/examples/admin.py
@@ -35,7 +35,7 @@ from examples.models import LdapGroup, LdapUser
 
 
 class LdapGroupAdmin(admin.ModelAdmin):
-    exclude = ['dn', 'usernames']
+    exclude = ['dn', 'usernames', 'member']
     list_display = ['name', 'gid']
     search_fields = ['name']
 

--- a/examples/models.py
+++ b/examples/models.py
@@ -83,6 +83,7 @@ class LdapGroup(ldapdb.models.Model):
     gid = IntegerField(db_column='gidNumber', unique=True)
     name = CharField(db_column='cn', max_length=200, primary_key=True)
     usernames = ListField(db_column='memberUid')
+    member = ListField(db_column='member', default=['user1','user2'])
 
     def __str__(self):
         return self.name

--- a/examples/tests.py
+++ b/examples/tests.py
@@ -268,6 +268,7 @@ class GroupTestCase(TestCase):
         self.assertEquals(new.name, 'newgroup')
         self.assertEquals(new.gid, 1010)
         self.assertEquals(new.usernames, ['someuser', 'foouser'])
+        self.assertEquals(new.member, ['user1', 'user2'])
 
     def test_order_by(self):
         # ascending name
@@ -609,7 +610,7 @@ class AdminTestCase(TestCase):
         self.ldapobj.search_s.seed(
             "ou=groups,dc=nodomain", 2,
             "(&(objectClass=posixGroup)(cn=*foo*))",
-            ['gidNumber', 'cn', 'memberUid'])([foogroup])
+            ['gidNumber', 'cn', 'memberUid', 'member'])([foogroup])
         response = self.client.get('/admin/examples/ldapgroup/?q=foo')
         self.assertContains(response, "Ldap groups")
         self.assertContains(response, "foogroup")

--- a/ldapdb/models/fields.py
+++ b/ldapdb/models/fields.py
@@ -31,6 +31,7 @@
 #
 
 from django.db.models import fields, SubfieldBase
+from django.utils.encoding import force_unicode
 
 from ldapdb import escape_ldap_filter
 
@@ -177,6 +178,13 @@ class ListField(fields.Field):
         if lookup_type == 'contains':
             return escape_ldap_filter(value)
         raise TypeError("ListField has invalid lookup: %s" % lookup_type)
+
+    def get_default(self):
+        "Encode every item and return the list if a default is defined."
+        if self.has_default():
+            return [force_unicode(i, strings_only=True) for i in self.default]
+        else:
+            return ""
 
     def to_python(self, value):
         if not value:


### PR DESCRIPTION
This overrides the get_default method of Django Class "Field". It will
encode every item of a ListField's "default" attribute (which should
always be a list if defined).
