### PR TITLE
Py3 django1.9

### DIFF
--- a/ldapdb/backends/ldap/compiler.py
+++ b/ldapdb/backends/ldap/compiler.py
@@ -35,6 +35,7 @@ from __future__ import unicode_literals
 import ldap
 import re
 import sys
+from functools import cmp_to_key
 
 import django
 if django.VERSION >= (1, 8):
@@ -222,7 +223,7 @@ class SQLCompiler(compiler.SQLCompiler):
                 if val:
                     return val
             return 0
-        vals = sorted(vals, cmp=cmpvals)
+        vals = sorted(vals, key=cmp_to_key(cmpvals))
 
         # process results
         pos = 0

--- a/ldapdb/models/base.py
+++ b/ldapdb/models/base.py
@@ -37,7 +37,6 @@ import logging
 
 import django.db.models
 from django.db import connections, router
-from django.db.models import signals
 
 import ldapdb  # noqa
 
@@ -179,3 +178,6 @@ class Model(django.db.models.base.Model):
 
     class Meta:
         abstract = True
+
+
+from django.db.models import signals

--- a/ldapdb/models/base.py
+++ b/ldapdb/models/base.py
@@ -37,6 +37,7 @@ import logging
 
 import django.db.models
 from django.db import connections, router
+from django.db.models import signals
 
 import ldapdb  # noqa
 
@@ -180,4 +181,3 @@ class Model(django.db.models.base.Model):
         abstract = True
 
 
-from django.db.models import signals


### PR DESCRIPTION
ignore the first commit. it did not work well and was reverted.

The cmp attribute to sorted() was removed in python3. Using functools.cmp_to_key for the key attribute to sorted() adapts the functionality. 