### PR TITLE
fixes deprecation warning for django 1.9

### DIFF
--- a/ldapdb/router.py
+++ b/ldapdb/router.py
@@ -32,8 +32,8 @@ class Router(object):
             return db == self.ldap_alias
         return None
 
-    def allow_migrate(self, db, model):
-        if is_ldap_model(model):
+    def allow_migrate(self, db, app_label, model_name=None, **hints):
+        if db == self.ldap_alias:
             return False
         return None
 


### PR DESCRIPTION
This fixes a deprecation warning on startup:

```
Django-1.9-py3.5.egg/django/db/utils.py:316: RemovedInDjango110Warning: The signature of allow_migrate has changed from allow_migrate(self, db, model) to allow_migrate(self, db, app_label, model_name=None, **hints). Support for the old signature will be removed in Django 1.10.
  RemovedInDjango110Warning)
```

and apparently this error if using multiple database:

```
Traceback (most recent call last):
  File "./manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/home/oggei/.virtualenvs/py35-useradmin/lib/python3.5/site-packages/Django-1.9-py3.5.egg/django/core/management/__init__.py", line 350, in execute_from_command_line
    utility.execute()
  File "/home/oggei/.virtualenvs/py35-useradmin/lib/python3.5/site-packages/Django-1.9-py3.5.egg/django/core/management/__init__.py", line 342, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/oggei/.virtualenvs/py35-useradmin/lib/python3.5/site-packages/Django-1.9-py3.5.egg/django/core/management/base.py", line 348, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/home/oggei/.virtualenvs/py35-useradmin/lib/python3.5/site-packages/Django-1.9-py3.5.egg/django/core/management/base.py", line 399, in execute
    output = self.handle(*args, **options)
  File "/home/oggei/.virtualenvs/py35-useradmin/lib/python3.5/site-packages/django_extensions-1.6.7-py3.5.egg/django_extensions/management/utils.py", line 58, in inner
    ret = func(self, *args, **kwargs)
  File "/home/oggei/.virtualenvs/py35-useradmin/lib/python3.5/site-packages/django_extensions-1.6.7-py3.5.egg/django_extensions/management/commands/runserver_plus.py", line 352, in handle
    inner_run()
  File "/home/oggei/.virtualenvs/py35-useradmin/lib/python3.5/site-packages/django_extensions-1.6.7-py3.5.egg/django_extensions/management/commands/runserver_plus.py", line 263, in inner_run
    self.check(display_num_errors=self.show_startup_messages)
  File "/home/oggei/.virtualenvs/py35-useradmin/lib/python3.5/site-packages/Django-1.9-py3.5.egg/django/core/management/base.py", line 426, in check
    include_deployment_checks=include_deployment_checks,
  File "/home/oggei/.virtualenvs/py35-useradmin/lib/python3.5/site-packages/Django-1.9-py3.5.egg/django/core/checks/registry.py", line 75, in run_checks
    new_errors = check(app_configs=app_configs)
  File "/home/oggei/.virtualenvs/py35-useradmin/lib/python3.5/site-packages/Django-1.9-py3.5.egg/django/core/checks/model_checks.py", line 28, in check_all_models
    errors.extend(model.check(**kwargs))
  File "/home/oggei/.virtualenvs/py35-useradmin/lib/python3.5/site-packages/Django-1.9-py3.5.egg/django/db/models/base.py", line 1170, in check
    errors.extend(cls._check_fields(**kwargs))
  File "/home/oggei/.virtualenvs/py35-useradmin/lib/python3.5/site-packages/Django-1.9-py3.5.egg/django/db/models/base.py", line 1247, in _check_fields
    errors.extend(field.check(**kwargs))
  File "/home/oggei/.virtualenvs/py35-useradmin/lib/python3.5/site-packages/Django-1.9-py3.5.egg/django/db/models/fields/__init__.py", line 925, in check
    errors = super(AutoField, self).check(**kwargs)
  File "/home/oggei/.virtualenvs/py35-useradmin/lib/python3.5/site-packages/Django-1.9-py3.5.egg/django/db/models/fields/__init__.py", line 208, in check
    errors.extend(self._check_backend_specific_checks(**kwargs))
  File "/home/oggei/.virtualenvs/py35-useradmin/lib/python3.5/site-packages/Django-1.9-py3.5.egg/django/db/models/fields/__init__.py", line 317, in _check_backend_specific_checks
    return connections[db].validation.check_field(self, **kwargs)
AttributeError: 'DatabaseWrapper' object has no attribute 'validation'
```

HTH ciao