### PR TITLE
Patch for compatibility with 1.9.x

### DIFF
--- a/ldapdb/backends/ldap/base.py
+++ b/ldapdb/backends/ldap/base.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 
 import ldap
 import django
-from django.db.backends.base.validation import BaseDatabaseValidation
 
 if django.VERSION < (1, 8):
     from django.db.backends import (BaseDatabaseFeatures, BaseDatabaseOperations,
@@ -17,6 +16,7 @@ else:
     from django.db.backends.base.operations import BaseDatabaseOperations
     from django.db.backends.base.base import BaseDatabaseWrapper
     from django.db.backends.base.creation import BaseDatabaseCreation
+    from django.db.backends.base.validation import BaseDatabaseValidation
 
 
 class DatabaseCreation(BaseDatabaseCreation):
@@ -181,7 +181,9 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         self.ops = DatabaseOperations(self)
         self.settings_dict['SUPPORTS_TRANSACTIONS'] = True
         self.autocommit = True
-        self.validation = BaseDatabaseValidation(self)
+
+        if django.VERSION >= (1, 8):
+            self.validation = BaseDatabaseValidation(self)
 
     def close(self):
         if hasattr(self, 'validate_thread_sharing'):

--- a/ldapdb/backends/ldap/base.py
+++ b/ldapdb/backends/ldap/base.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 
 import ldap
 import django
+from django.db.backends.base.validation import BaseDatabaseValidation
 
 if django.VERSION < (1, 8):
     from django.db.backends import (BaseDatabaseFeatures, BaseDatabaseOperations,
@@ -16,7 +17,6 @@ else:
     from django.db.backends.base.operations import BaseDatabaseOperations
     from django.db.backends.base.base import BaseDatabaseWrapper
     from django.db.backends.base.creation import BaseDatabaseCreation
-    from django.db.backends.base.validation import BaseDatabaseValidation
 
 
 class DatabaseCreation(BaseDatabaseCreation):

--- a/ldapdb/backends/ldap/base.py
+++ b/ldapdb/backends/ldap/base.py
@@ -16,6 +16,7 @@ else:
     from django.db.backends.base.operations import BaseDatabaseOperations
     from django.db.backends.base.base import BaseDatabaseWrapper
     from django.db.backends.base.creation import BaseDatabaseCreation
+    from django.db.backends.base.validation import BaseDatabaseValidation
 
 
 class DatabaseCreation(BaseDatabaseCreation):
@@ -180,6 +181,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         self.ops = DatabaseOperations(self)
         self.settings_dict['SUPPORTS_TRANSACTIONS'] = True
         self.autocommit = True
+        self.validation = BaseDatabaseValidation(self)
 
     def close(self):
         if hasattr(self, 'validate_thread_sharing'):


### PR DESCRIPTION
This is a patch to resolve compatibility [issue](https://github.com/django-ldapdb/django-ldapdb/issues/92) with django versions above 1.8.14.
We added missing attribute "self.validation = BaseDatabaseValidation(self)" in __init__ method of the DatabaseWrapper class imported from django.db.backends.base.validation.
Tested with Python 3.4.3.
