### PR TITLE
Fixes AttributeError: 'DatabaseWrapper' object has no attribute 'validation'

### DIFF
--- a/ldapdb/backends/ldap/base.py
+++ b/ldapdb/backends/ldap/base.py
@@ -16,6 +16,7 @@ else:
     from django.db.backends.base.operations import BaseDatabaseOperations
     from django.db.backends.base.base import BaseDatabaseWrapper
     from django.db.backends.base.creation import BaseDatabaseCreation
+    from django.db.backends.base.validation import BaseDatabaseValidation
 
 
 class DatabaseCreation(BaseDatabaseCreation):
@@ -180,6 +181,8 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         self.ops = DatabaseOperations(self)
         self.settings_dict['SUPPORTS_TRANSACTIONS'] = True
         self.autocommit = True
+        if django.VERSION >= (1, 8):
+            self.validation = BaseDatabaseValidation(self)
 
     def close(self):
         if hasattr(self, 'validate_thread_sharing'):


### PR DESCRIPTION
This is a patch to resolve compatibility [issue](https://github.com/django-ldapdb/django-ldapdb/issues/92) with django versions above 1.8.14.
We added missing attribute "self.validation = BaseDatabaseValidation(self)" in __init__ method of the DatabaseWrapper class imported from django.db.backends.base.validation.
Tested with Python 3.4.3.