### PR TITLE
backends.ldap: add timeout and paginated results

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,3 +114,20 @@ and add this to your ``admin.py``:
     
     For instance in the example above, a group whose cn is ``foo``
     will have the DN ``cn=foo,ou=groups,dc=nodomain,dc=org``.
+
+
+Tuning django-ldapdb
+--------------------
+
+It is possible to adjust django-ldapdb's behavior by defining a few parameters in the ``DATABASE`` section:
+
+``PAGE_SIZE`` (default: ``1000``)
+    Define the maximum size of a results page to be returned by the server
+
+``QUERY_TIMEOUT`` (default: no limit)
+    Define the maximum time in seconds we'll wait to get a reply from the server (on a per-query basis).
+
+    .. note:: This setting applies on individual requests; if a high-level operation requires many
+              queries (for instance a paginated search yielding thousands of entries),
+              the timeout will be used on each individual request;
+              the overall processing time might be much higher.

--- a/examples/admin.py
+++ b/examples/admin.py
@@ -18,5 +18,6 @@ class LdapUserAdmin(admin.ModelAdmin):
     list_display = ['username', 'first_name', 'last_name', 'email', 'uid']
     search_fields = ['first_name', 'last_name', 'full_name', 'username']
 
+
 admin.site.register(LdapGroup, LdapGroupAdmin)
 admin.site.register(LdapUser, LdapUserAdmin)

--- a/examples/tests.py
+++ b/examples/tests.py
@@ -436,6 +436,31 @@ class GroupTestCase(BaseTestCase):
         qs = LdapGroup.objects.all()
         self.assertEqual(len(qs), 2)
 
+    def test_paginated_search(self):
+        # This test will change the settings, assert we don't break things
+        self.assertIsNone(settings.DATABASES['ldap'].get('CONNECTION_OPTIONS', {}).get('page_size'))
+
+        # Test without BATCH_SIZE
+        qs = LdapGroup.objects.filter(name__contains='group').order_by('name')
+        self.assertEqual(len(qs), 3)
+        self.assertEqual(qs[0].name, 'bargroup')
+        self.assertEqual(qs[1].name, 'foogroup')
+        self.assertEqual(qs[2].name, 'wizgroup')
+
+        # Set new page size
+        settings.DATABASES['ldap']['CONNECTION_OPTIONS'] = settings.DATABASES['ldap'].get('CONNECTION_OPTIONS', {})
+        settings.DATABASES['ldap']['CONNECTION_OPTIONS']['page_size'] = 1
+        connections['ldap'].close()  # Force connection reload
+
+        qs = LdapGroup.objects.filter(name__contains='group').order_by('name')
+        self.assertEqual(len(qs), 3)
+        self.assertEqual(qs[0].name, 'bargroup')
+        self.assertEqual(qs[1].name, 'foogroup')
+        self.assertEqual(qs[2].name, 'wizgroup')
+
+        # Restore previous configuration
+        del settings.DATABASES['ldap']['CONNECTION_OPTIONS']['page_size']
+
 
 class UserTestCase(BaseTestCase):
     directory = dict([groups, people, foouser])

--- a/ldapdb/__init__.py
+++ b/ldapdb/__init__.py
@@ -16,6 +16,7 @@ def escape_ldap_filter(value):
         text_value = str(value)
     return ldap.filter.escape_filter_chars(text_value)
 
+
 # Legacy single database support
 if hasattr(settings, 'LDAPDB_SERVER_URI'):
     from django import db

--- a/ldapdb/backends/ldap/base.py
+++ b/ldapdb/backends/ldap/base.py
@@ -5,6 +5,7 @@
 from __future__ import unicode_literals
 
 import ldap
+import ldap.controls
 
 from django.db.backends.base.features import BaseDatabaseFeatures
 from django.db.backends.base.operations import BaseDatabaseOperations
@@ -180,6 +181,9 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         self.validation = DatabaseValidation(self)
         self.settings_dict['SUPPORTS_TRANSACTIONS'] = True
         self.autocommit = True
+        # Default page size of 1000 items, ActiveDirectory's default
+        # See https://support.microsoft.com/en-us/help/315071/how-to-view-and-set-ldap-policy-in-active-directory-by-using-ntdsutil.exe  # noqa
+        self.page_size = 1000
 
     def close(self):
         if hasattr(self, 'validate_thread_sharing'):
@@ -208,7 +212,12 @@ class DatabaseWrapper(BaseDatabaseWrapper):
 
         options = conn_params['options']
         for opt, value in options.items():
-            connection.set_option(opt, value)
+            if opt.lower() == 'query_timeout':
+                connection.timeout = int(value)
+            elif opt.lower() == 'page_size':
+                self.page_size = int(value)
+            else:
+                connection.set_option(opt, value)
 
         if conn_params['tls']:
             connection.start_tls_s()
@@ -252,13 +261,42 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         cursor = self._cursor()
         return cursor.connection.rename_s(dn, newrdn)
 
-    def search_s(self, base, scope, filterstr='(objectClass=*)',
-                 attrlist=None):
+    def search_s(self, base, scope, filterstr='(objectClass=*)', attrlist=None):
         cursor = self._cursor()
-        results = cursor.connection.search_s(base, scope, filterstr, attrlist)
-        output = []
-        for dn, attrs in results:
-            # skip referrals
-            if dn is not None:
-                output.append((dn, attrs))
-        return output
+        query_timeout = cursor.connection.timeout
+
+        # Request pagination; don't fail if the server doesn't support it.
+        ldap_control = ldap.controls.SimplePagedResultsControl(
+            criticality=False,
+            size=self.page_size,
+            cookie='',
+        )
+
+        # Fetch results
+        page = 0
+
+        while True:
+            msgid = cursor.connection.search_ext(
+                base=base,
+                scope=scope,
+                filterstr=filterstr,
+                attrlist=attrlist,
+                serverctrls=[ldap_control],
+                timeout=query_timeout,
+            )
+
+            _res_type, results, _res_msgid, server_controls = cursor.connection.result3(msgid, timeout=query_timeout)
+            page_controls = [ctrl for ctrl in server_controls if ctrl.controlType == ldap.CONTROL_PAGEDRESULTS]
+
+            for dn, attrs in results:
+                # skip referrals
+                if dn is not None:
+                    yield dn, attrs
+
+            page_control = page_controls[0]
+            page += 1
+            if page_control.cookie:
+                ldap_control.cookie = page_control.cookie
+            else:
+                # End of pages
+                break

--- a/ldapdb/backends/ldap/compiler.py
+++ b/ldapdb/backends/ldap/compiler.py
@@ -129,6 +129,8 @@ class SQLCompiler(compiler.SQLCompiler):
                 filterstr=lookup.filterstr,
                 attrlist=['dn'],
             )
+            # Flatten iterator
+            vals = list(vals)
         except ldap.NO_SUCH_OBJECT:
             vals = []
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,4 +2,4 @@
 check-manifest
 flake8
 factory_boy
-volatildap
+volatildap>=1.1.0


### PR DESCRIPTION
I propose to add two options:
 - ``DATABASES['ldap']['CONNECTION_OPTIONS']['TIMEOUT'] = 2``
   which allows to define the database connection timeout
   (not a big deal).
 - ``DATABASES['ldap']['CONNECTION_OPTIONS']['BATCH_SIZE'] = 500``
   which allows to split requests to the LDAP, thus allowing
   to fetch more data in a single request.

This second option uses `search_ext_s` if defined, and continues
to use previous `search_s` if not. That's why I renamed
`DatabaseWrapper.search_s` with `batched_search_s`.