### PR TITLE
Use ReconnectLDAPObject to survive temporary LDAP issues (See #80)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,14 @@
 ChangeLog
 =========
 
+.. _v0.8.0:
+
+0.8.0 (2017-01-17)
+------------------
+
+*New:*
+    * Use ReconnectLDAPObject to survive temporary LDAP issues
+
 .. _v0.7.0:
 
 0.7.0 (2016-10-24)

--- a/ldapdb/backends/ldap/base.py
+++ b/ldapdb/backends/ldap/base.py
@@ -189,6 +189,28 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             self.connection.unbind_s()
             self.connection = None
 
+    def ensure_connection(self):
+        if self.connection is None:
+            self.connection = ldap.ldapobject.ReconnectLDAPObject(
+                uri=self.settings_dict['NAME'],
+                retry_max=self.settings_dict.get('RETRY_MAX', 1),
+                retry_delay=self.settings_dict.get('RETRY_DELAY', 60.0),
+                bytes_mode=False)
+
+            conn_params = self.get_connection_params()
+
+            options = conn_params['options']
+            for opt, value in options.items():
+                self.connection.set_option(opt, value)
+
+            if conn_params['tls']:
+                self.connection.start_tls_s()
+
+            self.connection.simple_bind_s(
+                conn_params['bind_dn'],
+                conn_params['bind_pw'],
+            )
+
     def get_connection_params(self):
         """Compute appropriate parameters for establishing a new connection.
 
@@ -201,23 +223,6 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             'bind_pw': self.settings_dict['PASSWORD'],
             'options': self.settings_dict.get('CONNECTION_OPTIONS', {}),
         }
-
-    def get_new_connection(self, conn_params):
-        """Build a connection from its parameters."""
-        connection = ldap.initialize(conn_params['uri'], bytes_mode=False)
-
-        options = conn_params['options']
-        for opt, value in options.items():
-            connection.set_option(opt, value)
-
-        if conn_params['tls']:
-            connection.start_tls_s()
-
-        connection.simple_bind_s(
-            conn_params['bind_dn'],
-            conn_params['bind_pw'],
-        )
-        return connection
 
     def init_connection_state(self):
         """Initialize python-side connection state."""

--- a/ldapdb/version.py
+++ b/ldapdb/version.py
@@ -4,4 +4,4 @@
 
 from __future__ import unicode_literals
 
-VERSION = '0.7.0'
+VERSION = '0.8.0'

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def get_version(package_name):
     return '0.1.0'
 
 
-PACKAGE = 'django-ldapdb'
+PACKAGE = 'django-ldapdb-ugent'
 PYPACKAGE = 'ldapdb'
 
 
@@ -42,11 +42,11 @@ setup(
     maintainer_email="raphael.barrois+%s@polytechnique.org" % PACKAGE,
     license="BSD",
     keywords=['django', 'ldap', 'database'],
-    url="https://github.com/{pn}/{pn}".format(pn=PACKAGE),
+    url="https://github.com/UGentPortaal/django-ldapdb-ugent",
     packages=find_packages(exclude=['tests*', 'examples*']),
     install_requires=[
         'Django>=1.8',
-        'pyldap>=2.4.25',
+        'pyldap-ugent>=2.4.28',
     ],
     setup_requires=[
         'setuptools>=0.8',


### PR DESCRIPTION
As proposed in #80.

The retry settings retry_max and retry_delay (see https://www.python-ldap.org/doc/html/ldap.html#ldap.ReconnectLDAPObject) are configurable by adding for example
```
    'RETRY_MAX': 10,
    'RETRY_DELAY': 10.0,
```
to the LDAP database configuration settings.

Reconnections will only be attempted if a connection was previously opened successfully (see https://mail.python.org/pipermail/python-ldap/2011q3/002945.html).

As the commit in this pull request uses the ReconnectLDAPObject and django-ldapdb supports Python 2, the pull request will only be mergeable when pyldap supports the `bytes_mode` parameter on the ReconnectLDAPObject (see https://github.com/pyldap/pyldap/pull/72).