### PR TITLE
Actually register gte and lte lookups for DateField

### DIFF
--- a/ldapdb/models/fields.py
+++ b/ldapdb/models/fields.py
@@ -243,3 +243,5 @@ class DateField(fields.DateField):
 
 
 DateField.register_lookup(ExactLookup)
+DateField.register_lookup(GteLookup)
+DateField.register_lookup(LteLookup)

--- a/ldapdb/tests.py
+++ b/ldapdb/tests.py
@@ -150,6 +150,14 @@ class WhereTestCase(TestCase):
         where.add(self._build_lookup("birthday", 'exact', '2013-09-03', field=DateField), AND)
         self.assertEqual(self._where_as_ldap(where), "(birthday=2013-09-03)")
 
+        where = WhereNode()
+        where.add(self._build_lookup("birthday", 'gte', '2013-09-03', field=DateField), AND)
+        self.assertEqual(self._where_as_ldap(where), "(birthday>=2013-09-03)")
+
+        where = WhereNode()
+        where.add(self._build_lookup("birthday", 'lte', '2013-09-03', field=DateField), AND)
+        self.assertEqual(self._where_as_ldap(where), "(birthday<=2013-09-03)")
+
     def test_and(self):
         where = WhereNode()
         where.add(self._build_lookup("cn", 'exact', "foo", field=CharField), AND)


### PR DESCRIPTION
Same same as #130 but with minimal unit tests to allow a merge.

I still need your input, because, in my setup, dates are *not* stored in ISO 8601 extended format.

I think the format used in the search filter should, at least, use the date representation set in the field format (in my case it is `%Y%m%d%H%M%SZ`).

I'm quite allergic to the LDAP format, so your enlightenment will be welcome, but what I [could](https://stackoverflow.com/a/18632573) [find](https://docs.oracle.com/cd/E19450-01/820-6173/def-greater-than-or-equal-search-filter.html) [around](http://www.openldap.org/lists/openldap-software/200603/msg00330.html) seems to point that the filter should be in [generalized time](https://tools.ietf.org/html/rfc4517#section-3.3.13):

> The LDAP-specific encoding of a value of this syntax is a restriction of the format defined in ISO8601