### PR TITLE
Use DN to retrieve old object on save, closes #159.

### DIFF
--- a/ldapdb/models/base.py
+++ b/ldapdb/models/base.py
@@ -27,10 +27,6 @@ class Model(django.db.models.base.Model):
     search_scope = ldap.SCOPE_SUBTREE
     object_classes = ['top']
 
-    def __init__(self, *args, **kwargs):
-        super(Model, self).__init__(*args, **kwargs)
-        self.saved_pk = self.pk
-
     def build_rdn(self):
         """
         Build the Relative Distinguished Name for this entry.
@@ -90,7 +86,7 @@ class Model(django.db.models.base.Model):
         if create:
             old = None
         else:
-            old = cls.objects.using(using).get(pk=self.saved_pk)
+            old = cls.objects.using(using).get(dn=self.dn)
         changes = {
             field.db_column: (
                 None if old is None else get_field_value(field, old),
@@ -144,7 +140,6 @@ class Model(django.db.models.base.Model):
         self.dn = new_dn
 
         # Finishing
-        self.saved_pk = self.pk
         return updated
 
     @classmethod


### PR DESCRIPTION
This fixes updating of multi-PK objects that share one PK field with another object.