### PR TITLE
Silence E026 (single primary key) system check for ldapdb models

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,10 @@ matrix:
       env: TOXENV=py35-django20
     - python: "3.6"
       env: TOXENV=py36-django20
+    - python: "3.5"
+      env: TOXENV=py35-django21
+    - python: "3.6"
+      env: TOXENV=py36-django21
 
     # Linting
     - python: "3.6"

--- a/ldapdb/models/base.py
+++ b/ldapdb/models/base.py
@@ -164,5 +164,13 @@ class Model(django.db.models.base.Model):
             'Meta': Meta})
         return new_class
 
+    @classmethod
+    def _check_single_primary_key(cls):
+        """
+        Always return an empty list to circumvent the models.E026 system check.
+        ldapdb allows multiple primary keys.
+        """
+        return []
+
     class Meta:
         abstract = True

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
-envlist = py{27,34,35,36}-django111, py{34,35,36,37}-django20, lint
+envlist = py{27,34,35,36}-django111, py{34,35,36,37}-django20, py{35,36,37}-django21, lint
 
 [testenv]
 deps =
     -rrequirements_test.txt
     django111: Django>=1.11,<1.12
     django20: Django>=2.0,<2.1
+    django21: Django>=2.1,<2.2
 
 whitelist_externals = make
 commands = make test


### PR DESCRIPTION
This is one proposal to silence the new system check in Django 2.1 (see #175). It overloads the check function in the ldapdb base model. Thus, we can keep using primary_key to mark RDN fields.

I will merge on Sunday if noone objects.