### PR TITLE
[models.base.Model] editable=False in Field will prevents save/update

### DIFF
--- a/ldapdb/backends/ldap/base.py
+++ b/ldapdb/backends/ldap/base.py
@@ -214,7 +214,12 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             # django >= 1.4
             self.validate_thread_sharing()
         if self.connection is not None:
-            self.connection.unbind_s()
+            # AttributeError: ReconnectLDAPObject has no attribute '_l'
+            try:
+                self.connection.unbind_s()
+            except Exception as e:
+                # print(e)
+                pass
             self.connection = None
 
     def get_connection_params(self):

--- a/ldapdb/models/base.py
+++ b/ldapdb/models/base.py
@@ -90,13 +90,12 @@ class Model(django.db.models.base.Model):
             old = None
         else:
             old = cls.objects.using(using).get(dn=self._saved_dn)
-        changes = {
-            field.db_column: (
-                None if old is None else get_field_value(field, old),
-                get_field_value(field, self),
-            )
-            for field in target_fields
-        }
+        changes = {}
+        for field in target_fields:
+            if field.editable:
+                s = (None if old is None else get_field_value(field, old),
+                     get_field_value(field, self))
+                changes[field.db_column] = s
 
         # Actual saving
 


### PR DESCRIPTION
This will permit us to use editable=False in readonly fields like:

 -   memberOf = MultiValueField(db_column='memberOf', editable=False, null=True)
 -   createTimestamp =  DateTimeField(db_column='createTimestamp', editable=False, null=True)
 -   modifyTimestamp =  DateTimeField(db_column='modifyTimestamp', editable=False, null=True)
 -    creatorsName = CharField(db_column='creatorsName', editable=False, null=True)
 -   modifiersName = CharField(db_column='modifiersName', editable=False, null=True)

 PPolicy field example:
 -    pwdFailureTime = MultiValueField(db_column='pwdFailureTime', editable=False)
 -   pwdChangedTime = TimeStampField(db_column='pwdChangedTime', editable=False)