### PR TITLE
A safe unbind_s

### DIFF
--- a/ldapdb/backends/ldap/base.py
+++ b/ldapdb/backends/ldap/base.py
@@ -214,7 +214,12 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             # django >= 1.4
             self.validate_thread_sharing()
         if self.connection is not None:
-            self.connection.unbind_s()
+            # AttributeError: ReconnectLDAPObject has no attribute '_l'
+            try:
+                self.connection.unbind_s()
+            except Exception as e:
+                print(e)
+                #pass
             self.connection = None
 
     def get_connection_params(self):


### PR DESCRIPTION
This fixes a strange behaviour when I use django-ldapdb with my [AdminModels UI](https://github.com/peppelinux/django-ldap-academia-ou-manager). 

Using separate uwsgi workers, could happen that a worker gets out of sync with connection to LDAP server and this patch tries to unbind first, because a normal unbind on a desynced connection will raise an Exception.