### PR TITLE
[WIP] Removed dn field from Base Abstract ldapdb Model

### DIFF
--- a/examples/models.py
+++ b/examples/models.py
@@ -15,6 +15,8 @@ class LdapUser(ldapdb.models.Model):
     # LDAP meta-data
     base_dn = "ou=people,dc=example,dc=org"
     object_classes = ['posixAccount', 'shadowAccount', 'inetOrgPerson']
+
+    dn = fields.CharField(max_length=200, primary_key=True)
     last_modified = fields.DateTimeField(db_column='modifyTimestamp')
 
     # inetOrgPerson
@@ -52,6 +54,7 @@ class LdapGroup(ldapdb.models.Model):
     # LDAP meta-data
     base_dn = "ou=groups,dc=example,dc=org"
     object_classes = ['posixGroup']
+    dn = fields.CharField(max_length=200, primary_key=True)
 
     # posixGroup attributes
     gid = fields.IntegerField(db_column='gidNumber', unique=True)
@@ -74,6 +77,7 @@ class LdapMultiPKRoom(ldapdb.models.Model):
     object_classes = ['room']
 
     # room attributes
+    dn = fields.CharField(max_length=200, primary_key=True)
     name = fields.CharField(db_column='cn', max_length=200, primary_key=True)
     number = fields.CharField(db_column='roomNumber', max_length=10, primary_key=True)
     phone = fields.CharField(db_column='telephoneNumber', max_length=20, blank=True, null=True)
@@ -100,3 +104,4 @@ class AbstractGroup(ldapdb.models.Model):
 
 class ConcreteGroup(AbstractGroup):
     base_dn = "ou=groups,dc=example,dc=org"
+    dn = fields.CharField(max_length=200, primary_key=True)

--- a/ldapdb/models/base.py
+++ b/ldapdb/models/base.py
@@ -20,8 +20,6 @@ class Model(django.db.models.base.Model):
     """
     Base class for all LDAP models.
     """
-    dn = ldapdb_fields.CharField(max_length=200, primary_key=True)
-
     # meta-data
     base_dn = None
     search_scope = ldap.SCOPE_SUBTREE


### PR DESCRIPTION
fixes: https://github.com/django-ldapdb/django-ldapdb/issues/186

Now I can have a fully working Model Inheritance, as follow:

````
import ldapdb.models

from django.utils.translation import gettext as _
from ldapdb.models.fields import CharField
from . model_fields import ListField, EmailListField


class LdapUser(ldapdb.models.Model):
    """
    Class for representing an LDAP user entry.
    """

    class Meta:
        abstract = True

    object_classes = ['inetOrgPerson',
                      'organizationalPerson',
                      'person']

    # inetOrgPerson
    uid = CharField(db_column='uid',
                    verbose_name="User ID",
                    help_text="uid",
                    primary_key=True)
    cn = CharField(db_column='cn',
                     verbose_name=_("Name"),
                     help_text='cn',
                     blank=False)
    givenName = CharField(db_column='givenName',
                          help_text="givenName",
                          verbose_name=_("First Name"),
                          blank=True, null=True)
    sn = CharField("Final name", db_column='sn',
                   help_text='sn',
                   blank=False)
    displayName = CharField(db_column='displayName',
                            help_text='displayName',
                            blank=True, null=True)
    telephoneNumber = ListField(db_column='telephoneNumber',
                                blank=True)
    mail = EmailListField(db_column='mail',
                          default='',
                          blank=True, null=True)
    userPassword = CharField(db_column='userPassword',
                             verbose_name="LDAP Password",
                             blank=True, null=True)
                             # editable=False)


class LdapSambaUser(ldapdb.models.Model):

    class Meta:
        abstract = True

    object_classes = ['sambaSamAccount',]

    sambaNTPassword = CharField(db_column='sambaNTPassword',
                                help_text=_("SAMBA NT Password (freeRadius PEAP)"),
                                blank=True, null=True,) # editable=False)


class LdapAcademiaUser(LdapUser, LdapSambaUser, LdapSerializer):
    """
    Class for representing an LDAP user entry.
    """
    # LDAP meta-data
    base_dn = "ou={},{}".format(settings.LDAP_OU,
                                settings.LDAP_BASEDN)

    object_classes = ['inetOrgPerson',
                      'organizationalPerson',
                      'person',
                      # WARNING: only who have these OC will be filtered
                      'userSecurityInformation',
                      'eduPerson',
                      'radiusprofile',
                      'sambaSamAccount',
                      'schacContactLocation',
                      'schacEmployeeInfo',
                      'schacEntryConfidentiality',
                      'schacEntryMetadata',
                      'schacExperimentalOC',
                      'schacGroupMembership',
                      'schacLinkageIdentifiers',
                      'schacPersonalCharacteristics',
                      'schacUserEntitlements']

    dn = CharField(max_length=200, primary_key=True)
````

The child class MUST have dn field declared to get it to work.
Tested with objects creation and modification, also throu ModelAdmin.