### PR TITLE
Use _base_manager instead of objects when modifying model

### DIFF
--- a/examples/models.py
+++ b/examples/models.py
@@ -2,6 +2,8 @@
 # This software is distributed under the two-clause BSD license.
 # Copyright (c) The django-ldapdb project
 
+from django.db.models import Manager
+
 import ldapdb.models
 from ldapdb.models import fields
 
@@ -98,3 +100,14 @@ class AbstractGroup(ldapdb.models.Model):
 
 class ConcreteGroup(AbstractGroup):
     base_dn = "ou=groups,dc=example,dc=org"
+
+
+class FooNamePrefixManager(Manager):
+    def get_queryset(self):
+        return super(FooNamePrefixManager, self).get_queryset().filter(
+            name__startswith='foo')
+
+
+class FooGroup(AbstractGroup):
+    base_dn = "ou=groups,dc=example,dc=org"
+    objects = FooNamePrefixManager()

--- a/ldapdb/models/base.py
+++ b/ldapdb/models/base.py
@@ -89,7 +89,7 @@ class Model(django.db.models.base.Model):
         if create:
             old = None
         else:
-            old = cls.objects.using(using).get(dn=self._saved_dn)
+            old = cls._base_manager.using(using).get(dn=self._saved_dn)
         changes = {
             field.db_column: (
                 None if old is None else get_field_value(field, old),


### PR DESCRIPTION
Guard against issues with a non-empty default QuerySet returned by
a Model's Manager instance by calling the Model's _base_manager when
doing lookups by dn. LDAP lookups by dn must be done by setting the dn
as the base of the LDAP query.

The current method for determining if a dn lookup is being requested
relies on inspecting the generated django.db.models.sql.query.Query and
looking for a 'dn' target column in the first where clause statement. If
a Model uses a custom Manager to append a where clause statement to all
QuerySets, this logic is broken. Using _base_manager instead of objects
as the Manager for constructing explicit dn lookups avoids this problem.
This behavior also matches the Django documentation and internals for
related object access, so it is likely to continue to work for the
foreseeable future.

Fixes #196