### PR TITLE
Optimize how updates are done in _save() method

### DIFF
--- a/ldapdb/models/base.py
+++ b/ldapdb/models/base.py
@@ -128,11 +128,15 @@ class Model(django.db.models.base.Model):
                 old_value, new_value = change
                 if old_value == new_value:
                     continue
-                modlist.append((
-                    ldap.MOD_DELETE if new_value == [] else ldap.MOD_REPLACE,
-                    colname,
-                    new_value,
-                ))
+                elif len(old_value) == len(new_value):
+                    operation = ldap.MOD_REPLACE
+                elif len(old_value) > len(new_value):
+                    operation = ldap.MOD_DELETE
+                    new_value = list(set(old_value) - set(new_value))
+                else:
+                    operation = ldap.MOD_ADD
+                    new_value = list(set(new_value) - set(old_value))
+                modlist.append((operation, colname, new_value))
 
             if new_dn != old_dn:
                 logger.debug("renaming ldap entry %s to %s", old_dn, new_dn)


### PR DESCRIPTION
`django-ldapdb` library always issues an `ldap.MOD_REPLACE` request to the LDAP server when saving an updated LDAP entry. This can cause big delays in some cases.

Imagine you have a model representing a LDAP group with a field of type `ListField`. That field is used to store the group members. If your group has thousands of members, when you add/remove a member `django-ldapdb` sends the whole list of members (thousands) to the LDAP server.

This PR sends ldap.MOD_REPLACE, ldap.MOD_DELETE or ldap.MOD_ADD depending on
how the value changes instead of always sending ldap.MOD_REPLACE.

