### PR TITLE
Use class attribute to guide RDN creation

### DIFF
--- a/ldapdb/models/base.py
+++ b/ldapdb/models/base.py
@@ -24,6 +24,7 @@ class Model(django.db.models.base.Model):
     base_dn = None
     search_scope = ldap.SCOPE_SUBTREE
     object_classes = ['top']
+    rdn_fields = []
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -37,7 +38,7 @@ class Model(django.db.models.base.Model):
         """
         bits = []
         for field in self._meta.fields:
-            if field.db_column and field.primary_key:
+            if field.db_column and field.name in self.rdn_fields:
                 bits.append("%s=%s" % (field.db_column,
                                        getattr(self, field.name)))
         if not len(bits):


### PR DESCRIPTION
So in #175 it was mentioned that, ideally, the whole process of creating the RDN should be separate from designating primary keys for the database table.

@Natureshadow mentioned they were not keen on such a major rewrite, though.

But looking at the code, I believe there's quite an easy path, namely a simple class attribute, for which I propose `rdn_fields`, taking a list of field names. The code for `build_rdn` is trivial to change.

As far as the user is concerned:

1. They are already expected to add some class attributes. Requiring one more should not be strange or surprising.
2. Previously, if they did not add a `primary_key` field, they got an error when saving. Now, if they do not add the class attribute, they get the exact same error at the exact same time.
3. Creating a list of field names is a common occurrence in Django: for Meta ordering, for the admin site, for a ModelForm, etc.

In short, as far as user experience goes, I do not see this as a major difference.

Is it backwards compatible? Well, not as I wrote it, no. But you can easily turn the if slightly more complicated to achieve that:
`    if field.db_column and (field.primary_key or field.name in self.rdn_fields):`